### PR TITLE
fix: should log if anything failed the switch

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -66,7 +66,7 @@ providers:
     base_url: https://api.x.ai/v1
     api_key: 
   ai-gateway:
-    base_url: https://ai-gateway.vercel.sh/v1/ai
+    base_url: https://ai-gateway.vercel.sh/v3/ai
     api_key: 
 
   # Local providers:

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -492,6 +492,10 @@ export class DiscordOperator {
         case "other":
           this.logger.logWarn(warn.message);
           break;
+        // for compatibility reasons, some adapters still return old warning types
+        default:
+          this.logger.logWarn("Unknown warning type", warn);
+          break;
       }
     }
   }


### PR DESCRIPTION
# Fix: should log if anything failed the switch

Added a default case to the warning type switch statement in `DiscordOperator` to log unknown warning types for compatibility with adapters that still return old warning types.

# Fix: should use v3 api for vercel

Updated the base URL for the ai-gateway provider from v1 to v3 in the config example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added handling for unknown warning types with appropriate logging.

* **Chores**
  * Updated API configuration to the latest API version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->