### PR TITLE
feat: infer vision support via models.dev registry

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -720,7 +720,12 @@ export class DiscordOperator {
   }
 
   private async messageToModelMessages(msg: Message, effectiveModel: string) {
-    const acceptImages = await this.canModelSeeImages(effectiveModel);
+    const hasImageAttachments = [...msg.attachments.values()].some((att) =>
+      att.contentType?.startsWith("image"),
+    );
+    const acceptImages = hasImageAttachments
+      ? await this.canModelSeeImages(effectiveModel)
+      : false;
     const maxText = this.cachedConfig.max_text ?? 100000;
     const maxImages = acceptImages ? (this.cachedConfig.max_images ?? 5) : 0;
 

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -48,22 +48,10 @@ import {
   withAnthropicSystemMessageCacheControl,
   withAnthropicToolCacheControl,
 } from "./utils/anthropic-cache";
-
-const VISION_MODEL_TAGS = [
-  "claude",
-  "gemini",
-  "gemma",
-  "gpt-4",
-  "gpt-5",
-  "grok-4",
-  "llama",
-  "llava",
-  "mistral",
-  "o3",
-  "o4",
-  "vision",
-  "vl",
-] as const;
+import {
+  ModelCapability,
+  providerModelToModelsDevSpecifier,
+} from "./utils/model-capability";
 
 const Warning = {
   maxText: "⚠️ Exceeding max text length per message.",
@@ -144,6 +132,8 @@ export class DiscordOperator {
   private logger = new Logger({ module: "discord" });
   private statusInterval: NodeJS.Timeout | null = null;
   private cancellationMap = new Map<string, AbortController>();
+  private modelCapability = new ModelCapability();
+  private visionSupportCache = new Map<string, boolean>();
 
   constructor() {
     this.client = new Client({
@@ -196,6 +186,7 @@ export class DiscordOperator {
 
   private async clientReady() {
     this.cachedConfig = await getConfig();
+    this.visionSupportCache.clear();
     await ensureCommands({
       client: this.client,
       commands,
@@ -227,6 +218,7 @@ export class DiscordOperator {
       getConfig,
       setCachedConfig: (config: Config) => {
         this.cachedConfig = config;
+        this.visionSupportCache.clear();
       },
       getCachedConfig: () => this.cachedConfig,
       getProviderModelForChannel: (channel: {
@@ -728,12 +720,7 @@ export class DiscordOperator {
   }
 
   private async messageToModelMessages(msg: Message, effectiveModel: string) {
-    const visionModels = (VISION_MODEL_TAGS as readonly string[]).concat(
-      this.cachedConfig.additional_vision_models || [],
-    );
-    const acceptImages = visionModels.some((t) =>
-      effectiveModel.toLowerCase().includes(t),
-    );
+    const acceptImages = await this.canModelSeeImages(effectiveModel);
     const maxText = this.cachedConfig.max_text ?? 100000;
     const maxImages = acceptImages ? (this.cachedConfig.max_images ?? 5) : 0;
 
@@ -917,6 +904,45 @@ export class DiscordOperator {
       this.logger.logError(e);
     }
     return { parent: null };
+  }
+
+  private async canModelSeeImages(providerModel: string): Promise<boolean> {
+    const cached = this.visionSupportCache.get(providerModel);
+    if (cached !== undefined) return cached;
+
+    // Explicit override.
+    if (/:vision$/i.test(providerModel)) {
+      this.visionSupportCache.set(providerModel, true);
+      return true;
+    }
+
+    // Escape hatch for custom / private providers not present in models.dev.
+    const extra = this.cachedConfig.additional_vision_models ?? [];
+    const lower = providerModel.toLowerCase();
+    if (extra.some((t) => lower.includes(String(t).toLowerCase()))) {
+      this.visionSupportCache.set(providerModel, true);
+      return true;
+    }
+
+    const spec = providerModelToModelsDevSpecifier(providerModel);
+    if (!spec) {
+      this.visionSupportCache.set(providerModel, false);
+      return false;
+    }
+
+    try {
+      const info = await this.modelCapability.resolve(spec);
+      const ok = Boolean(info.modalities?.input?.includes("image"));
+      this.visionSupportCache.set(providerModel, ok);
+      return ok;
+    } catch (e) {
+      this.logger.logDebug(
+        `[vision] capability lookup failed for '${spec}' (from '${providerModel}')`,
+      );
+      this.logger.logDebug(e);
+      this.visionSupportCache.set(providerModel, false);
+      return false;
+    }
   }
 
   private getChannelsAndRolesFromMessage(msg: Message) {

--- a/src/utils/model-capability.ts
+++ b/src/utils/model-capability.ts
@@ -1,0 +1,280 @@
+import type { LanguageModelUsage } from "ai";
+
+export type ModelSpecifier = string;
+
+export type ModelModality = "text" | "image" | "audio" | "video" | "pdf";
+
+export type ModelCost = {
+  /** USD per 1M input tokens. */
+  input: number;
+  /** USD per 1M output tokens. */
+  output: number;
+  /** USD per 1M cache read tokens (optional). */
+  cache_read?: number;
+  /** USD per 1M cache write tokens (optional). */
+  cache_write?: number;
+  /** USD per 1M input audio. */
+  input_audio?: number;
+  /** USD per 1M output audio. */
+  output_audio?: number;
+};
+
+export type ModelLimits = {
+  context: number;
+  output: number;
+};
+
+export type ModelCapabilityInfo = {
+  provider: string;
+  model: string;
+  name?: string;
+  family?: string;
+  env?: string[];
+  npm?: string;
+  doc?: string;
+  cost?: ModelCost;
+  limit: ModelLimits;
+  modalities?: {
+    input: ModelModality[];
+    output?: ModelModality[];
+  };
+};
+
+export type ModelCapabilityOverrides = Record<
+  ModelSpecifier,
+  {
+    cost?: ModelCost;
+    limit: {
+      context: number;
+      output?: number;
+    };
+    modalities?: {
+      input: ModelModality[];
+      output?: ModelModality[];
+    };
+  }
+>;
+
+export type ModelCapabilityOptions = {
+  /** Optional overrides that take priority over models.dev. */
+  overrides?: ModelCapabilityOverrides;
+  /** Optional provider alias mapping merged with defaults. */
+  providerAliases?: Record<string, string>;
+  /** Override models.dev URL for testing. */
+  apiUrl?: string;
+  /** Inject custom fetch implementation (defaults to global fetch). */
+  fetch?: typeof fetch;
+};
+
+const DEFAULT_PROVIDER_ALIASES = {
+  // js-llmcord provider id; models.dev uses "xai".
+  "x-ai": "xai",
+} as const satisfies Record<string, string>;
+
+type ModelsDevRegistry = Record<string, ModelsDevProvider>;
+
+type ModelsDevProvider = {
+  id: string;
+  env?: string[];
+  npm: string;
+  name: string;
+  doc?: string;
+  models: Record<string, ModelsDevModel>;
+};
+
+type ModelsDevModel = {
+  id: string;
+  name: string;
+  family: string;
+  attachment?: boolean;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  temperature?: boolean;
+  knowledge?: string;
+  release_date?: string;
+  last_updated?: string;
+  modalities: {
+    input: ModelModality[];
+    output: ModelModality[];
+  };
+  open_weights?: boolean;
+  cost?: ModelCost;
+  limit: ModelLimits;
+};
+
+export function parseModelSpecifier(spec: string): {
+  provider: string;
+  model: string;
+} {
+  const slashIndex = spec.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === spec.length - 1) {
+    throw new Error(
+      `Invalid model specifier '${spec}'. Expected format provider/modelstring.`,
+    );
+  }
+
+  return {
+    provider: spec.slice(0, slashIndex),
+    model: spec.slice(slashIndex + 1),
+  };
+}
+
+/**
+ * Converts js-llmcord's providerModel string into a models.dev-compatible
+ * specifier string.
+ *
+ * Special case: `ai-gateway/<adapter>/<model>` becomes `<adapter>/<model>`.
+ */
+export function providerModelToModelsDevSpecifier(
+  providerModel: string,
+): ModelSpecifier | null {
+  const clean = providerModel.trim().replace(/:vision$/i, "");
+  const firstSlash = clean.indexOf("/");
+  if (firstSlash <= 0 || firstSlash === clean.length - 1) return null;
+
+  const provider = clean.slice(0, firstSlash);
+  const model = clean.slice(firstSlash + 1);
+
+  if (provider !== "ai-gateway") return `${provider}/${model}`;
+
+  const secondSlash = model.indexOf("/");
+  if (secondSlash <= 0 || secondSlash === model.length - 1) return null;
+
+  const adapter = model.slice(0, secondSlash);
+  const upstreamModel = model.slice(secondSlash + 1);
+  return `${adapter}/${upstreamModel}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, unknown>;
+}
+
+function listSomeKeys(input: Record<string, unknown>, max: number): string[] {
+  return Object.keys(input).slice(0, max);
+}
+
+export class ModelCapability {
+  private readonly overrides: ModelCapabilityOverrides;
+  private readonly providerAliases: Record<string, string>;
+  private readonly apiUrl: string;
+  private readonly fetchFn: typeof fetch;
+
+  private registryPromise: Promise<ModelsDevRegistry> | null = null;
+
+  constructor(options?: ModelCapabilityOptions) {
+    this.overrides = options?.overrides ?? {};
+    this.providerAliases = {
+      ...DEFAULT_PROVIDER_ALIASES,
+      ...(options?.providerAliases ?? {}),
+    };
+    this.apiUrl = options?.apiUrl ?? "https://models.dev/api.json";
+    this.fetchFn = options?.fetch ?? fetch;
+  }
+
+  private normalizeProvider(provider: string): string {
+    return this.providerAliases[provider] ?? provider;
+  }
+
+  private async loadRegistry(signal?: AbortSignal): Promise<ModelsDevRegistry> {
+    if (!this.registryPromise) {
+      this.registryPromise = (async () => {
+        const res = await this.fetchFn(this.apiUrl, { signal });
+        if (!res.ok) {
+          throw new Error(
+            `Failed to fetch models.dev registry (${res.status} ${res.statusText})`,
+          );
+        }
+
+        const json = (await res.json()) as unknown;
+        const record = asRecord(json);
+        if (!record) {
+          throw new Error("models.dev registry JSON is not an object");
+        }
+
+        return record as ModelsDevRegistry;
+      })();
+    }
+
+    return await this.registryPromise;
+  }
+
+  async resolve(
+    spec: ModelSpecifier,
+    options?: { signal?: AbortSignal },
+  ): Promise<ModelCapabilityInfo> {
+    const override = this.overrides[spec];
+    if (override) {
+      const { provider, model } = parseModelSpecifier(spec);
+      return {
+        provider,
+        model,
+        cost: override.cost,
+        limit: {
+          context: override.limit.context,
+          output: override.limit.output ?? 0,
+        },
+        modalities: override.modalities,
+      };
+    }
+
+    const parsed = parseModelSpecifier(spec);
+    const provider = this.normalizeProvider(parsed.provider);
+
+    const registry = await this.loadRegistry(options?.signal);
+    const providerEntry = registry[provider];
+    if (!providerEntry) {
+      const available = listSomeKeys(registry, 10);
+      throw new Error(
+        `Unknown provider '${provider}' for spec '${spec}'. Add an override, or ensure models.dev contains it. Available providers (sample): ${available.join(", ")}`,
+      );
+    }
+
+    const modelEntry = providerEntry.models[parsed.model];
+    if (!modelEntry) {
+      const available = listSomeKeys(providerEntry.models, 10);
+      throw new Error(
+        `Unknown model '${parsed.model}' for provider '${provider}' (spec '${spec}'). Add an override, or ensure models.dev contains it. Available models (sample): ${available.join(", ")}`,
+      );
+    }
+
+    return {
+      provider: parsed.provider,
+      model: parsed.model,
+      name: modelEntry.name ?? providerEntry.name,
+      family: modelEntry.family,
+      env: providerEntry.env,
+      npm: providerEntry.npm,
+      doc: providerEntry.doc,
+      cost: modelEntry.cost,
+      limit: modelEntry.limit,
+      modalities: modelEntry.modalities,
+    };
+  }
+
+  estimateCostUsd(
+    info: Pick<ModelCapabilityInfo, "cost">,
+    usage: LanguageModelUsage,
+  ): number | undefined {
+    if (!info.cost) return undefined;
+
+    const inputTokens = usage.inputTokens ?? 0;
+    const outputTokens = usage.outputTokens ?? 0;
+
+    let total = 0;
+    total += (inputTokens / 1_000_000) * info.cost.input;
+    total += (outputTokens / 1_000_000) * info.cost.output;
+
+    const cacheReadTokens = usage.inputTokenDetails.cacheReadTokens ?? 0;
+    const cacheWriteTokens = usage.inputTokenDetails.cacheWriteTokens ?? 0;
+
+    if (info.cost.cache_read !== undefined) {
+      total += (cacheReadTokens / 1_000_000) * info.cost.cache_read;
+    }
+    if (info.cost.cache_write !== undefined) {
+      total += (cacheWriteTokens / 1_000_000) * info.cost.cache_write;
+    }
+
+    return total;
+  }
+}

--- a/tests/model-capability.test.ts
+++ b/tests/model-capability.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ModelCapability,
+  providerModelToModelsDevSpecifier,
+} from "../src/utils/model-capability";
+
+describe("model-capability", () => {
+  test("providerModelToModelsDevSpecifier handles ai-gateway", () => {
+    expect(providerModelToModelsDevSpecifier("ai-gateway/openai/gpt-4o")).toBe(
+      "openai/gpt-4o",
+    );
+  });
+
+  test("providerModelToModelsDevSpecifier strips :vision suffix", () => {
+    expect(providerModelToModelsDevSpecifier("openai/gpt-4o:vision")).toBe(
+      "openai/gpt-4o",
+    );
+  });
+
+  test("ModelCapability resolves using provider alias mapping", async () => {
+    const registry = {
+      xai: {
+        id: "xai",
+        npm: "@ai-sdk/xai",
+        name: "xAI",
+        models: {
+          "grok-2": {
+            id: "grok-2",
+            name: "Grok 2",
+            family: "grok",
+            modalities: { input: ["text", "image"], output: ["text"] },
+            limit: { context: 128000, output: 4096 },
+          },
+        },
+      },
+    };
+
+    const capability = new ModelCapability({
+      fetch: (async () =>
+        new Response(JSON.stringify(registry), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as unknown as typeof fetch,
+    });
+
+    const info = await capability.resolve("x-ai/grok-2");
+    expect(info.modalities?.input.includes("image")).toBe(true);
+  });
+});


### PR DESCRIPTION
Replaces the hard-coded VISION_MODEL_TAGS heuristic with a ModelCapability resolver backed by https://models.dev.

Vision support is now inferred from model modalities (input includes `image`).

Still supports:
- :vision suffix to force-enable image acceptance
- additional_vision_models as an escape hatch for private/custom providers

Includes unit tests for spec conversion + provider alias mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime capability queries to detect which models can process images.

* **Improvements**
  * Replaced static tag-based vision detection with a capability-driven flow.
  * Added caching for vision support with automatic cache clearing on startup and config updates.
  * Support for config overrides to mark additional vision-capable models.

* **Tests**
  * Added tests validating capability resolution and provider-model mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->